### PR TITLE
index.html: make the spec & library easier to find

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
 
 <p>There are literally thousands of different software update systems in common use today. (In fact the average Windows user has about two dozen different software updaters on their machine!)</p>
 
-<p>We are building a library that can be universally (and in most cases transparently) used to secure software update systems. </p>
+<p>We are building a <a href="https://github.com/theupdateframework/tuf/blob/develop/docs/tuf-spec.txt">specification</a></li> and <a href="https://github.com/theupdateframework/tuf">library</a> that can be universally (and in most cases transparently) used to secure software update systems. </p>
 
 <h2>
 <a id="how-do-i-learn-more" class="anchor" href="#how-do-i-learn-more" aria-hidden="true"><span class="octicon octicon-link"></span></a>How do I learn more?</h2>
@@ -61,15 +61,7 @@
 <p>For more information, look at the following:</p>
 
 <ul>
-<li>Papers
-
-<ul>
-<li><a href="https://isis.poly.edu/%7Ejcappos/papers/cappos_mirror_ccs_08.pdf">​A Look in the Mirror: Attacks on Package Managers</a></li>
-<li><a href="https://isis.poly.edu/%7Ejcappos/papers/cappos_pmsec_tr08-02.pdf">Package Management Security</a></li>
-<li><a href="https://isis.poly.edu/%7Ejcappos/papers/samuel_tuf_ccs_2010.pdf">Survivable Key Compromise in Software Update Systems</a></li>
-</ul>
-</li>
-<li><a href="https://github.com/theupdateframework/tuf/blob/develop/docs/tuf-spec.txt">General specification</a></li>
+<li><a href="https://github.com/theupdateframework/tuf/blob/develop/docs/tuf-spec.txt">The Update Framework Specification</a></li>
 <li><a href="https://github.com/theupdateframework/tuf">Source code</a></li>
 <li><a href="https://groups.google.com/forum/?fromgroups#%21forum/theupdateframework">Mailing list</a></li>
 </ul>
@@ -104,6 +96,16 @@
 <li><a href="http://corner.squareup.com/2013/12/securing-rubygems-with-tuf-part-2.html">Securing RubyGems with TUF, Part 2</a></li>
 <li><a href="http://corner.squareup.com/2013/12/securing-rubygems-with-tuf-part-3.html">Securing RubyGems with TUF, Part 3</a></li>
 </ul>
+
+<h3>
+<a id="papers" class="anchor" href="#papers" aria-hidden="true"></a>Papers</h3>
+
+<ul>
+<li><a href="https://isis.poly.edu/%7Ejcappos/papers/cappos_mirror_ccs_08.pdf">​A Look in the Mirror: Attacks on Package Managers</a></li>
+<li><a href="https://isis.poly.edu/%7Ejcappos/papers/cappos_pmsec_tr08-02.pdf">Package Management Security</a></li>
+<li><a href="https://isis.poly.edu/%7Ejcappos/papers/samuel_tuf_ccs_2010.pdf">Survivable Key Compromise in Software Update Systems</a></li>
+</ul>
+</li>
 
 <h3>
 <a id="other-implementations" class="anchor" href="#other-implementations" aria-hidden="true"><span class="octicon octicon-link"></span></a>Other implementations</h3>


### PR DESCRIPTION
When hitting the landing page it was hard for me to find the most important parts of TUF: the library and spec. Call these out as the first hyperlinks and push the papers to "more info" section.