### PR TITLE
index.html: Replace PEAR with composer

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 <li>
 <strong>Application updaters</strong> which are used by applications use to update themselves. For example, Firefox updates itself through its own application updater.</li>
 <li>
-<strong>Library package managers</strong> such as those offered by many programming languages for installing additional libraries. These are systems such as Python's pip/easy_install + PyPI, Perl's CPAN, Ruby's Gems, and PHP's PEAR.</li>
+<strong>Library package managers</strong> such as those offered by many programming languages for installing additional libraries. These are systems such as Python's pip/easy_install + PyPI, Perl's CPAN, Ruby's Gems, and PHP's composer.</li>
 <li>
 <strong>System package managers</strong> used by operating systems to update and install all of the software on a client system. Debian's APT, Red Hat's YUM, and openSUSE's YaST are examples of these.</li>
 </ul>


### PR DESCRIPTION
Composer has effectively replaced PEAR nowadays.