### PR TITLE
add links to conex release (opam signing)

### DIFF
--- a/index.md
+++ b/index.md
@@ -127,7 +127,9 @@ Papers:
 
 **Signing the OPAM Repository: TUF Meets Git**
 
-* [Proposal to secure the distribution of OCaml packages](https://opam.ocaml.org/blog/Signing-the-opam-repository/)
+* [Conex release announcement](https://hannes.nqsb.io/Posts/Conex)
+* [Implementation of conex](https://github.com/hannesm/conex)
+* [Initial proposal to secure the distribution of OCaml packages](https://opam.ocaml.org/blog/Signing-the-opam-repository/)
 
 **Other implementations**
 


### PR DESCRIPTION
next to the initial proposal from 2015, we now have an implementation available :)

feedback is of course welcome, and I'll hopefully manage to followup with a detailed comparison of conex vs tuf.  I suspect conex can be expressed in tuf with some policies (and has less features:  only a single level of delegations (or `authorisation`), which has to be approved by a quorum of janitors.