### PR TITLE
Fix link to specification

### DIFF
--- a/index.md
+++ b/index.md
@@ -121,7 +121,7 @@ https://blog.docker.com/2015/08/content-trust-docker-1-8/
 
 For more information, look at the following:
 
-* [The Update Framework Specification](https://github.com/theupdateframework/tuf/blob/develop/docs/tuf-spec.md)
+* [The Update Framework Specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md)
 * [Source code](https://github.com/theupdateframework/tuf)
 * [TUF Augmentation Proposals (TAPS)](https://github.com/theupdateframework/taps)
 * [Mailing list](https://groups.google.com/forum/?fromgroups#%21forum/theupdateframework)


### PR DESCRIPTION
The specification was recently moved to the repo at https://github.com/theupdateframework/specification/.  It previously lived in the theupdateframework/tuf repo.

This pull request edits the spec link on the website so that it points to the new location.

@jhdalek55
Thanks for reporting this issue.