### PR TITLE
Add process for reporting security vulnerabilities

### DIFF
--- a/index.md
+++ b/index.md
@@ -134,6 +134,18 @@ Papers:
 * [A Look in the Mirror: Attacks on Package Managers](https://isis.poly.edu/~jcappos/papers/cappos_mirror_ccs_08.pdf)
 * [Package Management Security](https://isis.poly.edu/~jcappos/papers/cappos_pmsec_tr08-02.pdf)
 
+## Security Issues
+
+Security issues can be reported by emailing justincappos@gmail.com.
+
+At a minimum, the report must contain the following:
+
+* Description of the vulnerability.
+* Steps to reproduce the issue.
+
+Optionally, reports that are emailed can be encrypted with PGP.  You should use
+PGP key fingerprint E9C0 59EC 0D32 64FA B35F  94AD 465B F9F6 F8EB 475.
+
 ## Integrations
 
 **Rust**


### PR DESCRIPTION
Publish, on the website, the process for reporting security vulnerabilities.  It is required by the CNCF.