### PR TITLE
Remove link to incomplete FAQ page

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -27,9 +27,6 @@
       url: https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#the-update-framework-specification
       external: true
 
-    - text: Frequently asked questions
-      url: /faq.html
-
     - text: Videos
       url: /videos.html
 


### PR DESCRIPTION
The FAQ page is incomplete at the moment.  We should only link to it once it's ready.

Signed-off-by: Vladimir Diaz <vladimir.v.diaz@gmail.com>