### PR TITLE
Link to Getting Started page for reference implementation

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -27,6 +27,8 @@
       url: https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#the-update-framework-specification
       external: true
 
+    - text: Reference Implementation
+      url: https://github.com/theupdateframework/tuf/blob/develop/docs/GETTING_STARTED.rst#getting-started
     - text: Videos
       url: /videos.html
 

--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -29,6 +29,7 @@
 
     - text: Reference Implementation
       url: https://github.com/theupdateframework/tuf/blob/develop/docs/GETTING_STARTED.rst#getting-started
+
     - text: Videos
       url: /videos.html
 


### PR DESCRIPTION
This pull request links to the Getting Started [page](https://github.com/theupdateframework/tuf/blob/develop/docs/GETTING_STARTED.rst#getting-started) for the reference implementation.

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>