### PR TITLE
Change 'Metadata' menu title to 'Roles & metadata'

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -20,7 +20,7 @@
     - text: Security
       url: /security.html
 
-    - text: Metadata
+    - text: Roles & metadata
       url: /metadata.html
 
     - text: Specification


### PR DESCRIPTION
This pull request modifies the `Metadata` sub-navigation element (under Getting Started) to `Roles & metadata`.  The new title now matches the page's heading.

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>